### PR TITLE
pp.c - fix for Perl_pow for ivsize== 4, nv is 'doubledouble'

### DIFF
--- a/pp.c
+++ b/pp.c
@@ -1206,6 +1206,20 @@ PP(pp_pow)
         } else {
             SETn( Perl_pow( left, right) );
         }
+#elif IVSIZE == 4 && defined(LONGDOUBLE_DOUBLEDOUBLE) && defined(USE_LONG_DOUBLE)
+    /*
+    Under these conditions, if a known libm bug exists, Perl_pow() could return
+    an incorrect value if the correct value is an integer in the range of around
+    25 or more bits. The error is always quite small, so we work around it by
+    rounding to the nearest integer value ... but only if is_int is true.
+    See https://github.com/Perl/perl5/issues/19625.
+    */
+
+        if (is_int) {
+            SETn( roundl( Perl_pow( left, right) ) );
+        }
+        else SETn( Perl_pow( left, right) );
+
 #else
         SETn( Perl_pow( left, right) );
 #endif  /* HAS_AIX_POWL_NEG_BASE_BUG */


### PR DESCRIPTION
Fixes #19625 - where some integers, when raised to an integer power, produced a non-integer result.
An example is that <code>3 ** 21</code> results in a non-integer value.
This causes the <code>"nan + getpayload 3 ** 21"</code> test in ext/POSIX/t/math.t to fail.

It's not a big deal to me if this PR be deemed unsatisfactory for inclusion in blead.
In that case I'll just apply the change privately to my perl source every time I build perl.

However, all the better (and easier for me) if this PR could be pushed after the release of perl-5.36.0.

Cheers,
Rob